### PR TITLE
Initial commit of Honeycomb 'QuickStart' Template

### DIFF
--- a/templates/cloudwatch-metrics.yml
+++ b/templates/cloudwatch-metrics.yml
@@ -17,6 +17,7 @@ Metadata:
           - HoneycombAPIHost
           - HttpBufferingInterval
           - HttpBufferingSize
+          - KinesisFirehoseArn
           - S3BackupMode
           - S3BufferingInterval
           - S3BufferingSize
@@ -45,6 +46,13 @@ Parameters:
     Description: The Kinesis Firehose http buffer size, in MiB.
     MinValue: 1
     MaxValue: 128
+  KinesisFirehoseArn:
+    Type: String
+    Default: ""
+    Description: >-
+      By default, a Kinesis Firehose Delivery Stream will be created.
+      You can override this behaviour by providing an Arn of an existing Firehose Delivery Stream.
+    ConstraintDescription: The Arn of an existing Kinesis Firehose Delivery Stream.
   S3BackupMode:
     Type: String
     Default: FailedDataOnly
@@ -69,9 +77,13 @@ Parameters:
     MinValue: 1
     MaxValue: 128
 
+Conditions:
+  CreateKinesisFirehose: !Equals [!Ref KinesisFirehoseArn, ""]
+
 Resources:
   KinesisToHoneycombStack:
     Type: AWS::CloudFormation::Stack
+    Condition: CreateKinesisFirehose
     Properties:
       TemplateURL: https://honeycomb-builds.s3.amazonaws.com/cloudformation-templates/latest/kinesis-firehose.yml
       Parameters:
@@ -106,20 +118,28 @@ Resources:
                 Action:
                   - "firehose:PutRecord"
                   - "firehose:PutRecordBatch"
-                Resource:
+                Resource: !If
+                  - CreateKinesisFirehose
                   - !GetAtt KinesisToHoneycombStack.Outputs.KinesisDeliveryStreamArn
+                  - Ref: KinesisFirehoseArn
   HoneycombCWLStream:
     Type: AWS::CloudWatch::MetricStream
     Properties:
       Name: !Sub "honeycomb-metric-stream-${AWS::StackName}"
       OutputFormat: opentelemetry0.7
-      FirehoseArn: !GetAtt KinesisToHoneycombStack.Outputs.KinesisDeliveryStreamArn
       RoleArn: !GetAtt HoneycombMetricStreamRole.Arn
+      FirehoseArn: !If
+        - CreateKinesisFirehose
+        - !GetAtt KinesisToHoneycombStack.Outputs.KinesisDeliveryStreamArn
+        - Ref: KinesisFirehoseArn
 
 Outputs:
   KinesisDeliveryStreamArn:
     Description: The ARN of the Firehose Delivery Stream
-    Value: !GetAtt KinesisToHoneycombStack.Outputs.KinesisDeliveryStreamArn
+    Value: !If
+      - CreateKinesisFirehose
+      - !GetAtt KinesisToHoneycombStack.Outputs.KinesisDeliveryStreamArn
+      - Ref: KinesisFirehoseArn
   MetricStreamArn:
     Description: The ARN of the Metric Stream
     Value: !GetAtt HoneycombCWLStream.Arn

--- a/templates/quickstart.yml
+++ b/templates/quickstart.yml
@@ -1,0 +1,89 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >-
+  Honeycomb AWS Integration
+
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: Required Parameters
+        Parameters:
+          - HoneycombAPIKey
+      - Label:
+          default: Optional Parameters
+        Parameters:
+          - HoneycombAPIHost
+          - EnableCloudWatchMetrics
+          - CloudWatchMetricsDataset
+          - CloudWatchLogsDataset
+
+Parameters:
+  HoneycombAPIKey:
+    Type: String
+    NoEcho: true
+    Description: Your Honeycomb Team's API key.
+  EnableCloudWatchMetrics:
+    Type: String
+    Default: "false"
+    Description: Honeycomb Enterprise customers can enable CloudWatch Metrics collection by setting this to true.
+    AllowedValues:
+      - "true"
+      - "false"
+  HoneycombAPIHost:
+    Type: String
+    Default: https://api.honeycomb.io
+    Description: Override the default Honeycomb API host.
+  CloudWatchLogsDataset:
+    Type: String
+    Default: cloudwatch-logs
+    Description: The name of the Honeycomb Dataset to publish CloudWatch Logs to.
+  CloudWatchMetricsDataset:
+    Type: String
+    Default: cloudwatch-metrics
+    Description: The name of the Honeycomb Dataset to publish CloudWatch Metrics to.
+
+Conditions:
+  MetricStreamEnabled: !Equals [!Ref EnableCloudWatchMetrics, "true"]
+
+Resources:
+  StreamFailureBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: Private
+      BucketName: !Sub "honeycomb-stream-failures-${AWS::StackName}"
+  HoneycombStream:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: https://honeycomb-builds.s3.amazonaws.com/cloudformation-templates/latest/kinesis-firehose.yml
+      Parameters:
+        Name: !Sub "honeycomb-${AWS::StackName}"
+        HoneycombAPIKey: !Ref HoneycombAPIKey
+        HoneycombAPIHost: !Ref HoneycombAPIHost
+        HoneycombDataset: !Ref CloudWatchLogsDataset
+        S3FailureBucketArn: !GetAtt StreamFailureBucket.Arn
+  MetricsStream:
+    Type: AWS::CloudFormation::Stack
+    Condition: MetricStreamEnabled
+    Properties:
+      TemplateURL: https://honeycomb-builds.s3.amazonaws.com/cloudformation-templates/latest/cloudwatch-metrics.yml
+      Parameters:
+        HoneycombAPIKey: !Ref HoneycombAPIKey
+        HoneycombAPIHost: !Ref HoneycombAPIHost
+        HoneycombDataset: !Ref CloudWatchMetricsDataset
+        S3FailureBucketArn: !GetAtt StreamFailureBucket.Arn
+
+Outputs:
+  FailureBucketArn:
+    Description: The ARN of the S3 Bucket created to hold stream delivery failures.
+    Value: !GetAtt StreamFailureBucket.Arn
+  KinesisStreamArn:
+    Description: The ARN of the Kinesis Firehose Stream sending data to Honeycomb
+    Value: !GetAtt HoneycombStream.Outputs.KinesisDeliveryStreamArn
+  MetricsStreamArn:
+    Condition: MetricStreamEnabled
+    Description: The ARN of the Metrics Stream.
+    Value: !GetAtt MetricsStream.Outputs.MetricStreamArn
+  MetricsStreamIAMRoleArn:
+    Condition: MetricStreamEnabled
+    Description: The ARN of the IAM Role created for the Metrics Stream
+    Value: !GetAtt MetricsStream.Outputs.MetricStreamIAMRoleArn


### PR DESCRIPTION
Will add conditionals for RDS and S3 logs in a follow-on commit to try to keep the size of the diff a bit more manageable.