### PR TITLE
Remove 'pro/enterprise only' disclaimer for metrics

### DIFF
--- a/templates/quickstart.yml
+++ b/templates/quickstart.yml
@@ -58,8 +58,7 @@ Parameters:
   EnableCloudWatchMetrics:
     Type: String
     Default: "false"
-    Description: Honeycomb Enterprise customers can enable CloudWatch Metrics collection by setting this to true.
-    ConstraintDescription: Requires a Honeycomb Enterprise plan.
+    Description: Enable CloudWatch Metrics collection.
     AllowedValues:
       - "true"
       - "false"


### PR DESCRIPTION
With today's announcement of Metrics available for all teams (Free -> Enterprise) these disclaimers are no longer needed.