### PR TITLE
ci: shorten assume role credential duration from (default) 6h to 10min

### DIFF
--- a/.github/workflows/publish-templates.yml
+++ b/.github/workflows/publish-templates.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          role-duration-seconds: 600 # 10 min
+          role-duration-seconds: 900 # 15min - lowest possible value
 
       - name: Publish Templates - PRs
         id: publish_prs

--- a/.github/workflows/publish-templates.yml
+++ b/.github/workflows/publish-templates.yml
@@ -27,8 +27,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-duration-seconds: 600 # 10 min
 
       - name: Publish Templates - PRs
         id: publish_prs

--- a/.github/workflows/validate-cloudformation-templates.yml
+++ b/.github/workflows/validate-cloudformation-templates.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
-          role-duration-seconds: 600 # 10 min
+          role-duration-seconds: 900 # 15min - lowest possible value
 
       - name: Validate Templates
         id: validate

--- a/.github/workflows/validate-cloudformation-templates.yml
+++ b/.github/workflows/validate-cloudformation-templates.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   validate-templates:
-    name: Valid CloudFormation Templates
+    name: Validate CloudFormation Templates
     runs-on: ubuntu-latest
     # These permissions are needed to interact with GitHub's OIDC Token endpoint.
     permissions:
@@ -21,8 +21,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          role-duration-seconds: 600 # 10 min
 
       - name: Validate Templates
         id: validate


### PR DESCRIPTION
No need for these AWS creds to be issued for so long in these pipelines.

5min is probably more than enough but I went with ~~10min~~ 15min as it's the lowest possible value.