### PR TITLE
rds-logs: add missing '!Ref' to AWS::NoValue

### DIFF
--- a/templates/rds-logs.yml
+++ b/templates/rds-logs.yml
@@ -176,7 +176,7 @@ Resources:
         TransformLambdaArn: !If
           - EnableLambdaTransform
           - !GetAtt TransformLambda.Arn
-          - AWS::NoValue
+          - !Ref "AWS::NoValue"
   TransformLambdaRole:
     Type: AWS::IAM::Role
     Condition: EnableLambdaTransform


### PR DESCRIPTION
Bug reported by customer during installation when selecting a "DBEngineType" other than `mysql` or `postgresql`.

Example of error message duration stack creation when creating the LambdaTransformS3Policy IAM Policy:

> Partition "" is not valid for resource "arn::NoValue:*:*:*"