### PR TITLE
maint: upgrade Lambdas from go1.x to provided.al2

### DIFF
--- a/templates/rds-logs.yml
+++ b/templates/rds-logs.yml
@@ -109,6 +109,13 @@ Parameters:
     Default: ""
     Description: The name of an additional CloudWatch Log Group to publish.
     MaxLength: 512
+  LambdaFunctionArchitecture:
+    Type: String
+    Default: amd64
+    Description: The instruction set architecture that the function supports. Valid values are arm64 or amd64.
+    AllowedValues:
+      - amd64
+      - arm64
   LambdaFunctionMemory:
     Type: Number
     Default: 192
@@ -150,6 +157,7 @@ Conditions:
   EnableLambdaTransform: !Or
     - !Equals [!Ref DBEngineType, "mysql"]
     - !Equals [!Ref DBEngineType, "postgresql"]
+  IsAMD64Arch: !Equals ["amd64", !Ref LambdaFunctionArchitecture]
 
 Resources:
   CWLtoHoneycombStack:
@@ -217,13 +225,15 @@ Resources:
       Handler: !Sub
         - "rds-${DBEngine}-kfh-transform"
         - DBEngine: !Ref DBEngineType
-      Runtime: "go1.x"
+      Runtime: "provided.al2"
+      Architectures:
+        - !If [IsAMD64Arch, "x86_64", "arm64"]
       MemorySize: !Ref LambdaFunctionMemory
       Timeout: !Ref LambdaFunctionTimeout
       PackageType: Zip
       Code:
         S3Bucket: !Sub "honeycomb-integrations-${AWS::Region}"
-        S3Key: agentless-integrations-for-aws/LATEST/ingest-handlers.zip
+        S3Key: !Sub "agentless-integrations-for-aws/LATEST/s3-handler-${LambdaFunctionArchitecture}.zip"
 
 Outputs:
   KinesisDeliveryStreamArn:

--- a/templates/s3-logfile.yml
+++ b/templates/s3-logfile.yml
@@ -59,6 +59,13 @@ Parameters:
     Type: String
     Default: ""
     Description: "KMS Key ID used to encrypt your Honeycomb write key (ex: a80d80aa-19b5-486a-a163-a4502b5555)"
+  LambdaFunctionArchitecture:
+    Type: String
+    Default: amd64
+    Description: The instruction set architecture that the function supports. Valid values are arm64 or amd64.
+    AllowedValues:
+      - amd64
+      - arm64
   LambdaFunctionMemory:
     Type: Number
     Default: 192
@@ -101,6 +108,7 @@ Parameters:
 
 Conditions:
   EncryptionEnabled: !Not [!Equals [!Ref KMSKeyId, ""]]
+  IsAMD64Arch: !Equals ["amd64", !Ref LambdaFunctionArchitecture]
 
 Resources:
   S3LambdaHandler:
@@ -109,14 +117,16 @@ Resources:
       FunctionName: !Sub "s3processor-${AWS::StackName}"
       Description: Parses logs from S3 and sends them to Honeycomb as structured logs.
       Handler: s3-handler
+      Architectures:
+        - !If [IsAMD64Arch, "x86_64", "arm64"]
       MemorySize: !Ref LambdaFunctionMemory
       Role: !GetAtt LambdaIAMRole.Arn
-      Runtime: "go1.x"
+      Runtime: "provided.al2"
       Timeout: !Ref LambdaFunctionTimeout
       PackageType: Zip
       Code:
         S3Bucket: !Sub "honeycomb-integrations-${AWS::Region}"
-        S3Key: agentless-integrations-for-aws/LATEST/ingest-handlers.zip
+        S3Key: !Sub "agentless-integrations-for-aws/LATEST/s3-handler-${LambdaFunctionArchitecture}.zip"
       Environment:
         Variables:
           PARSER_TYPE: !Ref ParserType


### PR DESCRIPTION
## Which problem is this PR solving?

- go1.x is being deprecated at the end of the year.

## Short description of the changes

Updates the Lambda functions in our CloudFormation templates to use `provided.al2` runtime and the new binaries that support that runtime.

Tested this by uploading the stack file to the console and running it the Lambda was created correctly with the new runtime!


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205731682619754