### PR TITLE
fix(rds-logs): use correct lambda archive for kfh-transform

### DIFF
--- a/templates/quickstart.yml
+++ b/templates/quickstart.yml
@@ -220,6 +220,11 @@ Rules:
 Resources:
   StreamFailureBucket:
     Type: AWS::S3::Bucket
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3045
     Properties:
       AccessControl: Private
       BucketName: !Sub "honeycomb-stream-failures-${AWS::StackName}"

--- a/templates/rds-logs.yml
+++ b/templates/rds-logs.yml
@@ -233,7 +233,7 @@ Resources:
       PackageType: Zip
       Code:
         S3Bucket: !Sub "honeycomb-integrations-${AWS::Region}"
-        S3Key: !Sub "agentless-integrations-for-aws/LATEST/s3-handler-${LambdaFunctionArchitecture}.zip"
+        S3Key: !Sub "agentless-integrations-for-aws/LATEST/rds-${DBEngineType}-kfh-transform-${LambdaFunctionArchitecture}.zip"
 
 Outputs:
   KinesisDeliveryStreamArn:


### PR DESCRIPTION
Customer reported that the `rds-logs` template failed to properly setup the Kinesis Firehose Transform Lambda with error messages similar to the following in the Lambda logs:

```
"Unable to initialize libhoney with the supplied environment variables" error="no value for HONEYCOMB_WRITE_KEY"
```

In the end, the s3-handler Lambda was being accidentally configured which _does_ require a Honeycomb API key.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206003942725992