### PR TITLE
fix: allow 64-character API keys

### DIFF
--- a/templates/cloudwatch-logs.yml
+++ b/templates/cloudwatch-logs.yml
@@ -35,7 +35,7 @@ Parameters:
   HoneycombAPIKey:
     Type: String
     NoEcho: true
-    Description: Your Honeycomb Team's API Key.
+    Description: Your Honeycomb API Key.
     MinLength: 1
     MaxLength: 64
   HoneycombDataset:

--- a/templates/cloudwatch-logs.yml
+++ b/templates/cloudwatch-logs.yml
@@ -35,9 +35,9 @@ Parameters:
   HoneycombAPIKey:
     Type: String
     NoEcho: true
-    Description: Your Honeycomb Team's API key.
+    Description: Your Honeycomb Team's API Key.
     MinLength: 1
-    MaxLength: 32
+    MaxLength: 64
   HoneycombDataset:
     Type: String
     Description: The target Honeycomb dataset for the Stream to publish to.

--- a/templates/cloudwatch-metrics.yml
+++ b/templates/cloudwatch-metrics.yml
@@ -34,7 +34,7 @@ Parameters:
   HoneycombAPIKey:
     Type: String
     NoEcho: true
-    Description: Your Honeycomb Team's API Key.
+    Description: Your Honeycomb API Key.
     MinLength: 1
     MaxLength: 64
   HoneycombDataset:

--- a/templates/cloudwatch-metrics.yml
+++ b/templates/cloudwatch-metrics.yml
@@ -34,9 +34,9 @@ Parameters:
   HoneycombAPIKey:
     Type: String
     NoEcho: true
-    Description: Your Honeycomb Team's API key.
+    Description: Your Honeycomb Team's API Key.
     MinLength: 1
-    MaxLength: 32
+    MaxLength: 64
   HoneycombDataset:
     Type: String
     Default: cloudwatch-metrics

--- a/templates/kinesis-firehose.yml
+++ b/templates/kinesis-firehose.yml
@@ -35,7 +35,7 @@ Parameters:
   HoneycombAPIKey:
     Type: String
     NoEcho: true
-    Description: Your Honeycomb Team's API Key.
+    Description: Your Honeycomb API Key.
     MinLength: 1
     MaxLength: 64
   HoneycombDataset:

--- a/templates/kinesis-firehose.yml
+++ b/templates/kinesis-firehose.yml
@@ -35,9 +35,9 @@ Parameters:
   HoneycombAPIKey:
     Type: String
     NoEcho: true
-    Description: Your Honeycomb Team's API key.
+    Description: Your Honeycomb Team's API Key.
     MinLength: 1
-    MaxLength: 32
+    MaxLength: 64
   HoneycombDataset:
     Type: String
     Description: The target Honeycomb dataset for the Stream to publish to.

--- a/templates/quickstart.yml
+++ b/templates/quickstart.yml
@@ -54,9 +54,9 @@ Parameters:
   HoneycombAPIKey:
     Type: String
     NoEcho: true
-    Description: Your Honeycomb Team's API key.
+    Description: Your Honeycomb Team's API Key.
     MinLength: 1
-    MaxLength: 32
+    MaxLength: 64
   EnableCloudWatchMetrics:
     Type: String
     Default: "false"

--- a/templates/quickstart.yml
+++ b/templates/quickstart.yml
@@ -54,7 +54,7 @@ Parameters:
   HoneycombAPIKey:
     Type: String
     NoEcho: true
-    Description: Your Honeycomb Team's API Key.
+    Description: Your Honeycomb API Key.
     MinLength: 1
     MaxLength: 64
   EnableCloudWatchMetrics:

--- a/templates/rds-logs.yml
+++ b/templates/rds-logs.yml
@@ -46,9 +46,9 @@ Parameters:
   HoneycombAPIKey:
     Type: String
     NoEcho: true
-    Description: Your Honeycomb Team's API key.
+    Description: Your Honeycomb Team's API Key.
     MinLength: 1
-    MaxLength: 32
+    MaxLength: 64
   HoneycombDataset:
     Type: String
     Description: The target Honeycomb dataset for the Stream to publish to.

--- a/templates/rds-logs.yml
+++ b/templates/rds-logs.yml
@@ -46,7 +46,7 @@ Parameters:
   HoneycombAPIKey:
     Type: String
     NoEcho: true
-    Description: Your Honeycomb Team's API Key.
+    Description: Your Honeycomb API Key.
     MinLength: 1
     MaxLength: 64
   HoneycombDataset:

--- a/templates/s3-logfile.yml
+++ b/templates/s3-logfile.yml
@@ -30,7 +30,7 @@ Parameters:
   HoneycombAPIKey:
     Type: String
     NoEcho: true
-    Description: Your Honeycomb Team's API Key.
+    Description: Your Honeycomb API Key.
     MinLength: 1
     MaxLength: 64
   HoneycombDataset:

--- a/templates/s3-logfile.yml
+++ b/templates/s3-logfile.yml
@@ -30,9 +30,9 @@ Parameters:
   HoneycombAPIKey:
     Type: String
     NoEcho: true
-    Description: Your Honeycomb Team's API key.
+    Description: Your Honeycomb Team's API Key.
     MinLength: 1
-    MaxLength: 32
+    MaxLength: 64
   HoneycombDataset:
     Type: String
     Description: The target Honeycomb dataset for the Stream to publish to.


### PR DESCRIPTION
Update our template field checks to allow 64 character API keys.