### PR TITLE
fix: use OpenTelemetry 1.0 format for CloudWatch MetricStream

### DIFF
--- a/templates/cloudwatch-metrics.yml
+++ b/templates/cloudwatch-metrics.yml
@@ -207,7 +207,7 @@ Resources:
     Type: AWS::CloudWatch::MetricStream
     Properties:
       Name: !Sub "honeycomb-metric-stream-${AWS::StackName}"
-      OutputFormat: opentelemetry0.7
+      OutputFormat: opentelemetry1.0
       RoleArn: !GetAtt HoneycombMetricStreamRole.Arn
       FirehoseArn: !If
         - CreateKinesisFirehose


### PR DESCRIPTION
Honeycomb's [Send Metrics from AWS CloudWatch
](https://docs.honeycomb.io/integrations/metrics/aws-cloudwatch/) doc specifies OpenTelemetry 1.0 format for the AWS CloudWatch Metric Stream. Use OpenTelemetry 1.0 output format instead of 0.7.

<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

Use current OpenTelemetry metrics format when sending CloudWatch Metrics to Honeycomb.

## Short description of the changes

 Use OpenTelemetry 1.0 output format instead of 0.7.

## How to verify that this has the expected result

Deploy CloudFormation template.

See [AWS Docs - AWS::CloudWatch::MetricStream
](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudwatch-metricstream.html#aws-resource-cloudwatch-metricstream-properties) for more details on the valid Output formats.

## Note

The same change should be made in the Honeycomb Terraform module.
