### PR TITLE
maint: update repo for pipeline team ownership

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Let us know if something is not working as expected
+title: ''
+labels: 'type: bug'
+assignees: ''
+
+---
+
+<!---
+Thank you for taking the time to report bugs!
+
+We love code snippets and links to repositories that reproduce the issue, but understand if you don't have the time to add them. We'll do our best with the info you provide, and might ask follow-up questions.
+
+Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
+--->
+
+**Versions**
+
+
+**Steps to reproduce**
+
+1.
+
+**Additional context**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'type: enhancement'
+assignees: ''
+
+---
+
+<!---
+Thank you for contributing an idea to this project!
+
+Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
+--->
+
+**Is your feature request related to a problem? Please describe.**
+
+
+**Describe the solution you'd like**
+
+
+**Describe alternatives you've considered**
+
+
+**Additional context**

--- a/.github/ISSUE_TEMPLATE/question-discussion.md
+++ b/.github/ISSUE_TEMPLATE/question-discussion.md
@@ -1,0 +1,14 @@
+---
+name: Question/Discussion
+about: General question about how things work or a discussion
+title: ''
+labels: 'type: discussion'
+assignees: ''
+
+---
+
+<!---
+Thank you for taking the time to say hello!
+
+Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
+--->

--- a/.github/ISSUE_TEMPLATE/security-vulnerability-report.md
+++ b/.github/ISSUE_TEMPLATE/security-vulnerability-report.md
@@ -1,0 +1,19 @@
+---
+name: Security vulnerability report
+about: Let us know if you discover a security vulnerability
+title: ''
+labels: 'type: security'
+assignees: ''
+
+---
+
+<!---
+Thank you for taking the time to report security vulnerabilities!
+
+Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
+--->
+**Versions**
+
+**Description**
+
+(Please include any relevant CVE advisory links)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!--
+Thank you for contributing to the project! 💜
+Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
+-->
+
+## Which problem is this PR solving?
+
+- Closes #<enter issue here>
+
+## Short description of the changes
+
+## How to verify that this has the expected result

--- a/.github/workflows/add-to-project-v2.yml
+++ b/.github/workflows/add-to-project-v2.yml
@@ -1,0 +1,15 @@
+name: Add to project
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    name: Add issues and PRs to project
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/honeycombio/projects/27
+          github-token: ${{ secrets.GHPROJECTS_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    name: 'Close stale issues and PRs'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-message: 'Marking this issue as stale because it has been open 14 days with no activity. Please add a comment if this is still an ongoing issue; otherwise this issue will be automatically closed in 7 days.'
+          stale-pr-message: 'Marking this PR as stale because it has been open 30 days with no activity. Please add a comment if this PR is still relevant; otherwise this PR will be automatically closed in 7 days.'
+          close-issue-message: 'Closing this issue due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
+          close-pr-message: 'Closing this PR due to inactivity. Please see our [Honeycomb OSS Lifecyle and Practices](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md).'
+          days-before-issue-stale: 14
+          days-before-pr-stale: 30
+          days-before-issue-close: 7
+          days-before-pr-close: 7
+          any-of-labels: 'status: info needed,status: revision needed'

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,0 +1,64 @@
+name: "Validate PR Title"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        id: lint_pr_title
+        name: "🤖 Check PR title follows conventional commit spec"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Have to specify all types because `maint` and `rel` aren't defaults
+          types: |
+            maint
+            rel
+            fix
+            feat
+            chore
+            ci
+            docs
+            style
+            refactor
+            perf
+            test
+          ignoreLabels: |
+            "type: dependencies"
+      # When the previous steps fails, the workflow would stop. By adding this
+      # condition you can continue the execution with the populated error message.
+      - if: always() && (steps.lint_pr_title.outputs.error_message != null)
+        name: "📝 Add PR comment about using conventional commit spec"
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          message: |
+            Thank you for contributing to the project! 🎉
+
+            We require pull request titles to follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) and it looks like your proposed title needs to be adjusted.
+
+            Make sure to prepend with `feat:`, `fix:`, or another option in the list below.
+
+            Once you update the title, this workflow will re-run automatically and validate the updated title.
+
+            Details:
+
+            ```
+            ${{ steps.lint_pr_title.outputs.error_message }}
+            ```
+
+      # Delete a previous comment when the issue has been resolved
+      - if: ${{ steps.lint_pr_title.outputs.error_message == null }}
+        name: "❌ Delete PR comment after title has been updated"
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-title-lint-error
+          delete: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,3 @@
 # Releasing
 
-- `Add steps to prepare release`
-- Update `CHANGELOG.md` with the changes since the last release.
-- Commit changes, push, and open a release preparation pull request for review.
-- Once the pull request is merged, fetch the updated `main` branch.
-- Apply a tag for the new version on the merged commit (e.g. `git tag -a v1.2.3 -m "v1.2.3"`)
-- Push the tag upstream (this will kick off the release pipeline in CI) e.g. `git push origin v1.2.3`
-- Copy change log entry for newest version into draft GitHub release created as part of CI publish steps.
-  - Make sure to "generate release notes" in github for full changelog notes and any new contributors
-- Publish the github draft release and this will kick off publishing to GitHub and the NPM registry.
+Releases do not get cut in this repo; when a change is merged, CI will publish the yml files to the AWS account.


### PR DESCRIPTION
## Which problem is this PR solving?

- finish handoff of repo to pipeline team

## Short description of the changes

- add github workflow for github project
- add PR and issue templates
- add stalebot and pr title validation workflows
- update releasing doc

Note: thus far releases have not been cut in this repo; when a change is merged, CI will publish the yml files to our AWS account. We may want to consider release steps in the future for tagging purposes, TBD.