### PR TITLE
maint: update AWS credendtials workflow step from v1 -> v4

### DIFF
--- a/.github/workflows/validate-cloudformation-templates.yml
+++ b/.github/workflows/validate-cloudformation-templates.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}


### PR DESCRIPTION
## Which problem is this PR solving?

Updates the AWS configure step used in the validate template workflow to use a newer version as v1 is now deprecated.

## Short description of the changes

- Update `configure-aws-credentials` step to use v4

## How to verify that this has the expected result

The workflow can now complete as it's using a supported version.