### PR TITLE
fix: Use AWS::Partition Pseudo Parameter in IAM ARNs

### DIFF
--- a/.github/workflows/validate-cloudformation-templates.yml
+++ b/.github/workflows/validate-cloudformation-templates.yml
@@ -36,8 +36,6 @@ jobs:
 
       - name: Setup Cloud Formation Linter with Latest Version
         uses: scottbrenner/cfn-lint-action@v2
-        with:
-          version: 1.*
 
       - name: Lint Templates
         id: lint

--- a/.github/workflows/validate-cloudformation-templates.yml
+++ b/.github/workflows/validate-cloudformation-templates.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Setup Cloud Formation Linter with Latest Version
         uses: scottbrenner/cfn-lint-action@v2
+        with:
+          version: 1.*
 
       - name: Lint Templates
         id: lint

--- a/templates/cloudwatch-logs.yml
+++ b/templates/cloudwatch-logs.yml
@@ -183,7 +183,7 @@ Resources:
             Condition:
               StringLike:
                 aws:SourceArn:
-                  - !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
+                  - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*"
       Policies:
         - PolicyName: !Sub "hnystream-${AWS::StackName}"
           PolicyDocument:

--- a/templates/rds-logs.yml
+++ b/templates/rds-logs.yml
@@ -199,7 +199,7 @@ Resources:
             Action:
               - "sts:AssumeRole"
       ManagedPolicyArns:
-        - "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
   TransformLambdaPolicy:
     Type: AWS::IAM::Policy
     Condition: EnableLambdaTransform

--- a/templates/rds-logs.yml
+++ b/templates/rds-logs.yml
@@ -199,7 +199,7 @@ Resources:
             Action:
               - "sts:AssumeRole"
       ManagedPolicyArns:
-        - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        - "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
   TransformLambdaPolicy:
     Type: AWS::IAM::Policy
     Condition: EnableLambdaTransform


### PR DESCRIPTION
## Which problem is this PR solving?

In AWS GovCloud, the RDS and CloudWatch Logs templates fail because the RDS and CloudWatch Logs templates contain IAM ARNs hardcoded with the AWS commercial partition (aws) instead of (aws-us-gov).

Example Error Message:

```shell
waiting for CloudFormation Stack (arn:aws-us-gov:cloudformation:us-gov-west-1:<redacted>) create: stack status (ROLLBACK_COMPLETE): The following resource(s) failed to create: [LogSubscription]. Rollback requested by user.
    	
    Resource handler returned message: "Invalid request provided: AWS::Logs::SubscriptionFilter. Could not deliver test message to specified Firehose stream. Check if the given Firehose stream is in ACTIVE state. (Service: CloudWatchLogs, Status Code: 400, Request ID: 123abc)" (RequestToken: 1fc17137-260a-91fe-803f-75e5cce376c2, HandlerErrorCode: InvalidRequest)
```

This PR is a copy of #37 but under Honeycomb's repository because of permissions issues
- Closes #37 
- Thank you to @dougireton for the details

## Short description of the changes

Swap the hardcoded AWS partition with the [AWS Partition Pseudo Parameter](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-partition), `AWS::Partition`

1. Allow CloudWatch Logs service in non-default AWS Partitions to assume LogStreamRole

2. For RDS Logs TransformLambdaRole, use correct AWSLambdaBasicExecutionRole ARN for non-default AWS Partitions


## How to verify that this has the expected result

Deploy RDS Logs or CloudWatch Logs templates in AWS GovCloud.
