### PR TITLE
fix: cloudwatch-metrics - update filters for MetricsStream resource

### DIFF
--- a/.github/workflows/validate-cloudformation-templates.yml
+++ b/.github/workflows/validate-cloudformation-templates.yml
@@ -36,7 +36,5 @@ jobs:
 
       - name: Setup Cloud Formation Linter with Latest Version
         uses: scottbrenner/cfn-lint-action@v2
-
-      - name: Lint Templates
-        id: lint
-        run: make lint-templates
+        with:
+          args: "templates/*.yml"

--- a/.github/workflows/validate-cloudformation-templates.yml
+++ b/.github/workflows/validate-cloudformation-templates.yml
@@ -36,5 +36,7 @@ jobs:
 
       - name: Setup Cloud Formation Linter with Latest Version
         uses: scottbrenner/cfn-lint-action@v2
-        with:
-          args: "templates/*.yml"
+
+      - name: Lint Templates
+        id: lint
+        run: make lint-templates

--- a/templates/cloudwatch-logs.yml
+++ b/templates/cloudwatch-logs.yml
@@ -6,14 +6,14 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          Default: Required Parameters
+          default: Required Parameters
         Parameters:
           - HoneycombAPIKey
           - HoneycombDataset
           - LogGroupName
           - S3FailureBucketArn
       - Label:
-          Default: Optional Parameters
+          default: Optional Parameters
         Parameters:
           - Name
           - HoneycombAPIHost

--- a/templates/cloudwatch-metrics.yml
+++ b/templates/cloudwatch-metrics.yml
@@ -6,12 +6,12 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          Default: Required Parameters
+          default: Required Parameters
         Parameters:
           - HoneycombAPIKey
           - S3FailureBucketArn
       - Label:
-          Default: "Optional: Metric Filtering"
+          default: "Optional: Metric Filtering"
         Parameters:
           - MetricFilterMethod
           - FilterNamespace
@@ -19,7 +19,7 @@ Metadata:
           - FilterNamespace2
           - FilterNamespace3
       - Label:
-          Default: Optional Parameters
+          default: Optional Parameters
         Parameters:
           - HoneycombAPIHost
           - HoneycombDataset

--- a/templates/cloudwatch-metrics.yml
+++ b/templates/cloudwatch-metrics.yml
@@ -120,6 +120,8 @@ Parameters:
 
 Conditions:
   CreateKinesisFirehose: !Equals [!Ref KinesisFirehoseArn, ""]
+  IsIncludeFilter: !Equals [!Ref MetricFilterMethod, "Include"]
+  IsExcludeFilter: !Not [!Equals [!Ref MetricFilterMethod, "Include"]]
   EnableIncludeNamespace:
     !And [
       !Not [!Equals [!Ref FilterNamespace, ""]],
@@ -213,40 +215,44 @@ Resources:
         - CreateKinesisFirehose
         - !GetAtt KinesisToHoneycombStack.Outputs.KinesisDeliveryStreamArn
         - Ref: KinesisFirehoseArn
-      IncludeFilters:
-        - !If
-          - EnableIncludeNamespace
-          - Namespace: !Ref FilterNamespace
-          - !Ref "AWS::NoValue"
-        - !If
-          - EnableIncludeNamespace1
-          - Namespace: !Ref FilterNamespace1
-          - !Ref "AWS::NoValue"
-        - !If
-          - EnableIncludeNamespace2
-          - Namespace: !Ref FilterNamespace2
-          - !Ref "AWS::NoValue"
-        - !If
-          - EnableIncludeNamespace3
-          - Namespace: !Ref FilterNamespace3
-          - !Ref "AWS::NoValue"
-      ExcludeFilters:
-        - !If
-          - EnableExcludeNamespace
-          - Namespace: !Ref FilterNamespace
-          - !Ref "AWS::NoValue"
-        - !If
-          - EnableExcludeNamespace1
-          - Namespace: !Ref FilterNamespace1
-          - !Ref "AWS::NoValue"
-        - !If
-          - EnableExcludeNamespace2
-          - Namespace: !Ref FilterNamespace2
-          - !Ref "AWS::NoValue"
-        - !If
-          - EnableExcludeNamespace3
-          - Namespace: !Ref FilterNamespace3
-          - !Ref "AWS::NoValue"
+      IncludeFilters: !If
+        - IsIncludeFilter
+        - - !If
+            - EnableIncludeNamespace
+            - Namespace: !Ref FilterNamespace
+            - !Ref "AWS::NoValue"
+          - !If
+            - EnableIncludeNamespace1
+            - Namespace: !Ref FilterNamespace1
+            - !Ref "AWS::NoValue"
+          - !If
+            - EnableIncludeNamespace2
+            - Namespace: !Ref FilterNamespace2
+            - !Ref "AWS::NoValue"
+          - !If
+            - EnableIncludeNamespace3
+            - Namespace: !Ref FilterNamespace3
+            - !Ref "AWS::NoValue"
+        - !Ref "AWS::NoValue"
+      ExcludeFilters: !If
+        - IsExcludeFilter
+        - - !If
+            - EnableExcludeNamespace
+            - Namespace: !Ref FilterNamespace
+            - !Ref "AWS::NoValue"
+          - !If
+            - EnableExcludeNamespace1
+            - Namespace: !Ref FilterNamespace1
+            - !Ref "AWS::NoValue"
+          - !If
+            - EnableExcludeNamespace2
+            - Namespace: !Ref FilterNamespace2
+            - !Ref "AWS::NoValue"
+          - !If
+            - EnableExcludeNamespace3
+            - Namespace: !Ref FilterNamespace3
+            - !Ref "AWS::NoValue"
+        - !Ref "AWS::NoValue"
 
 Outputs:
   KinesisDeliveryStreamArn:

--- a/templates/cloudwatch-metrics.yml
+++ b/templates/cloudwatch-metrics.yml
@@ -145,22 +145,22 @@ Conditions:
   EnableExcludeNamespace:
     !And [
       !Not [!Equals [!Ref FilterNamespace, ""]],
-      !Equals [!Ref MetricFilterMethod, "Exclude"],
+      !Not [!Equals [!Ref MetricFilterMethod, "Include"]],
     ]
   EnableExcludeNamespace1:
     !And [
       !Not [!Equals [!Ref FilterNamespace1, ""]],
-      !Equals [!Ref MetricFilterMethod, "Exclude"],
+      !Not [!Equals [!Ref MetricFilterMethod, "Include"]],
     ]
   EnableExcludeNamespace2:
     !And [
       !Not [!Equals [!Ref FilterNamespace2, ""]],
-      !Equals [!Ref MetricFilterMethod, "Exclude"],
+      !Not [!Equals [!Ref MetricFilterMethod, "Include"]],
     ]
   EnableExcludeNamespace3:
     !And [
       !Not [!Equals [!Ref FilterNamespace3, ""]],
-      !Equals [!Ref MetricFilterMethod, "Exclude"],
+      !Not [!Equals [!Ref MetricFilterMethod, "Include"]],
     ]
 
 Resources:

--- a/templates/cloudwatch-metrics.yml
+++ b/templates/cloudwatch-metrics.yml
@@ -207,6 +207,11 @@ Resources:
                   - Ref: KinesisFirehoseArn
   HoneycombCWLStream:
     Type: AWS::CloudWatch::MetricStream
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3018 # we're using !If to conditionally set the IncludeFilters and ExcludeFilters
     Properties:
       Name: !Sub "honeycomb-metric-stream-${AWS::StackName}"
       OutputFormat: opentelemetry1.0

--- a/templates/cloudwatch-metrics.yml
+++ b/templates/cloudwatch-metrics.yml
@@ -145,22 +145,22 @@ Conditions:
   EnableExcludeNamespace:
     !And [
       !Not [!Equals [!Ref FilterNamespace, ""]],
-      !Not [!Equals [!Ref MetricFilterMethod, "Include"]],
+      !Equals [!Ref MetricFilterMethod, "Exclude"],
     ]
   EnableExcludeNamespace1:
     !And [
       !Not [!Equals [!Ref FilterNamespace1, ""]],
-      !Not [!Equals [!Ref MetricFilterMethod, "Include"]],
+      !Equals [!Ref MetricFilterMethod, "Exclude"],
     ]
   EnableExcludeNamespace2:
     !And [
       !Not [!Equals [!Ref FilterNamespace2, ""]],
-      !Not [!Equals [!Ref MetricFilterMethod, "Include"]],
+      !Equals [!Ref MetricFilterMethod, "Exclude"],
     ]
   EnableExcludeNamespace3:
     !And [
       !Not [!Equals [!Ref FilterNamespace3, ""]],
-      !Not [!Equals [!Ref MetricFilterMethod, "Include"]],
+      !Equals [!Ref MetricFilterMethod, "Exclude"],
     ]
 
 Resources:

--- a/templates/kinesis-firehose.yml
+++ b/templates/kinesis-firehose.yml
@@ -9,14 +9,14 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          Default: Required Parameters
+          default: Required Parameters
         Parameters:
           - Name
           - HoneycombAPIKey
           - HoneycombDataset
           - S3FailureBucketArn
       - Label:
-          Default: Optional Parameters
+          default: Optional Parameters
         Parameters:
           - HoneycombAPIHost
           - HttpBufferingInterval

--- a/templates/quickstart.yml
+++ b/templates/quickstart.yml
@@ -6,20 +6,20 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          Default: Required Parameters
+          default: Required Parameters
         Parameters:
           - HoneycombAPIKey
       - Label:
-          Default: Optional Parameters
+          default: Optional Parameters
         Parameters:
           - HoneycombAPIHost
       - Label:
-          Default: "Optional: CloudWatch Metrics"
+          default: "Optional: CloudWatch Metrics"
         Parameters:
           - EnableCloudWatchMetrics
           - CloudWatchMetricsDataset
       - Label:
-          Default: "Optional: S3 Log Parsing"
+          default: "Optional: S3 Log Parsing"
         Parameters:
           - S3LogsDataset
           - S3LogsParserType
@@ -29,7 +29,7 @@ Metadata:
           - S3LogsFilterPrefix
           - S3LogsFilterSuffix
       - Label:
-          Default: "Optional: RDS Logs"
+          default: "Optional: RDS Logs"
         Parameters:
           - RDSLogsDataset
           - RDSDBEngineType
@@ -40,7 +40,7 @@ Metadata:
           - RDSLogGroupName4
           - RDSLogGroupName5
       - Label:
-          Default: "Optional: CloudWatch Logs"
+          default: "Optional: CloudWatch Logs"
         Parameters:
           - CloudWatchLogsDataset
           - LogGroupName

--- a/templates/rds-logs.yml
+++ b/templates/rds-logs.yml
@@ -6,7 +6,7 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          Default: Required Parameters
+          default: Required Parameters
         Parameters:
           - DBEngineType
           - HoneycombAPIKey
@@ -14,7 +14,7 @@ Metadata:
           - LogGroupName
           - S3FailureBucketArn
       - Label:
-          Default: Optional Parameters
+          default: Optional Parameters
         Parameters:
           - Name
           - HoneycombAPIHost

--- a/templates/s3-logfile.yml
+++ b/templates/s3-logfile.yml
@@ -6,14 +6,14 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          Default: Required Parameters
+          default: Required Parameters
         Parameters:
           - HoneycombAPIKey
           - HoneycombDataset
           - ParserType
           - S3BucketArn
       - Label:
-          Default: Optional Parameters
+          default: Optional Parameters
         Parameters:
           - HoneycombAPIHost
           - Environment


### PR DESCRIPTION
We received a report that the `cloudwatch-metrics` template is no longer passing validation and unusable as a result.

Seems that early this year a change was made to the `AWS::CloudWatch::MetricStream` resource  that enforces that only one of `ExcludeFilters` or `IncludeFilters` can be set.

We are currently passing an empty list (`[]`) for the filter option not being used which fails validation, this change in the conditional structure sets the YAML attribute to the CFN equivalent of null (`AWS::NoValue`)

`Default` -> `default` changes are linter appeasement.